### PR TITLE
Added highlighting tool directly into the site

### DIFF
--- a/bingosync-app/static/bingosync/room/additional_settings_panel.js
+++ b/bingosync-app/static/bingosync/room/additional_settings_panel.js
@@ -1,0 +1,118 @@
+var AdditionalSettingsPanel = (function(){
+    "use strict";
+
+    var AdditionalSettingsPanel = function($additionalSettings, $board) {
+        this.$additionalSettings = $additionalSettings;
+        this.$highlightsCheckbox =  $additionalSettings.find("#highlighter-toggle");
+
+        this.$board = $board;
+
+        this.initPanel();
+    };
+
+    AdditionalSettingsPanel.prototype.initPanel = function() {
+        var additionalSettingsPanel = this;
+
+        this.$highlightsCheckbox.on("change", function() {
+            additionalSettingsPanel.toggleHighlights(this.checked);
+        });
+
+        this.$additionalSettings.find("#additional-settings-collapse").on("mousedown", function() {
+            $("#additional-settings .panel-body").toggle(50);
+        });
+
+        this.$boardSetUp = false;
+    };
+
+    AdditionalSettingsPanel.prototype.COLORS = {
+        "red": "#6F0000",
+        "cyan": "#168A84",
+        "orange": "#8D4F12",
+        "pink": "#AE2691",
+        "green": "#207E10",
+        "grey": "#676767",
+        "purple": "#521F92",
+        "yellow": "#929006",
+    }
+
+    AdditionalSettingsPanel.prototype.HIGHLIGHTED_WORDS = {
+        "Hearts": "yellow",
+        "Berries": "red",
+        "Blue Hearts": "cyan",
+        "Blue Heart": "cyan",
+        "Blue": "cyan",
+        "Cassettes": "orange",
+        "Cassette": "orange",
+        "B-Sides": "pink",
+        "B-Side": "pink",
+        "Red Hearts": "pink",
+        "Red Heart": "pink",
+        "Collectibles": "green",
+        "Binoculars": "grey",
+        "Binocular": "grey",
+        "A-Sides": "purple",
+    }
+
+    AdditionalSettingsPanel.prototype.highlightSquare = function(HIGHLIGHTED_WORDS, square){
+        let textContainer = $(square).find(".text-container")[0];
+
+        let tileHTML = textContainer.innerHTML;
+
+        for (let word in HIGHLIGHTED_WORDS) {
+            if (word != "Hearts") {
+                tileHTML = tileHTML.replace(word, `<span class = "highlight-${HIGHLIGHTED_WORDS[word]}">${word}</span>`);
+            }
+            else {
+                if (!tileHTML.includes("Red Hearts") && !tileHTML.includes("Blue Hearts")){
+                    tileHTML = tileHTML.replace(word, `<span class = "highlight-${HIGHLIGHTED_WORDS[word]}">${word}</span>`);
+                }
+            }
+        }
+
+        textContainer.innerHTML = tileHTML;
+    }
+
+    AdditionalSettingsPanel.prototype.addHighlightsToBoard = function(){
+        if (this.$boardSetUp) return;
+
+        this.$boardSetUp = true;
+
+        let $tiles = this.$board.find(".square");
+
+        $tiles.each((_, tile) => this.highlightSquare(this.HIGHLIGHTED_WORDS, tile));
+
+    };
+
+    AdditionalSettingsPanel.prototype.newBoard = function(){
+        this.$boardSetUp = false;
+
+        if (this.$additionalSettings.find("#highlighter-toggle")[0].checked){
+            this.addHighlightsToBoard();
+            this.enableHighlights();
+        }
+    };
+
+    AdditionalSettingsPanel.prototype.enableHighlights = function() {
+        for (let color in this.COLORS) {
+            $(`.highlight-${color}`).css('background', this.COLORS[color])
+        }
+    }
+
+    AdditionalSettingsPanel.prototype.disableHighlights = function() {
+        for (let color in this.COLORS) {
+            $(`.highlight-${color}`).css('background', 'none')
+        }
+    }
+
+    AdditionalSettingsPanel.prototype.toggleHighlights = function(checked) {
+        if (checked){
+            this.addHighlightsToBoard();
+            this.enableHighlights();
+        }
+        else {
+            this.disableHighlights();
+        }
+    };
+
+    return AdditionalSettingsPanel;
+})();

--- a/bingosync-app/templates/bingosync/additional_settings_panel.html
+++ b/bingosync-app/templates/bingosync/additional_settings_panel.html
@@ -1,0 +1,17 @@
+<div id="additional-settings" class="panel panel-default fill-parent">
+    <div class="panel-heading">
+        <span>
+            Additional Settings
+        </span>
+        <span id="additional-settings-collapse" class="btn btn-default btn-xs pull-right collapse-button">
+            -
+        </span>
+    </div>
+    <div class="panel-body">
+        <div>
+            <div class="checkbox m-b-s" style="margin-top: 0">
+                <label><input id="highlighter-toggle" type="checkbox"> Accessibility Highlighter</label>
+            </div>
+        </div>
+    </div>
+</div>

--- a/bingosync-app/templates/bingosync/bingosync.html
+++ b/bingosync-app/templates/bingosync/bingosync.html
@@ -44,6 +44,12 @@
                         <div class="flex-col-footer m-b-l" id="room-settings-container">
                             {% include 'bingosync/room_settings_panel.html' %}
                         </div>
+                        <!-- Celeste Long New is the current name of the category extensions -->
+                        {% if room.settings.game == "Celeste" or room.settings.game == "Celeste Long New" or room.settings.game == "Custom" %}
+                            <div class="flex-col-footer m-b-l" id="additional-settings-container">
+                                {% include 'bingosync/additional_settings_panel.html' %}
+                            </div>
+                        {% endif %}
                         <div class="flex-col-footer">
                             {% include 'bingosync/chat_settings_panel.html' %}
                         </div>
@@ -60,6 +66,7 @@
 <script src="{% static "bingosync/room/board_cover.js" %}"></script>
 <script src="{% static "bingosync/room/players_panel.js" %}"></script>
 <script src="{% static "bingosync/room/room_settings_panel.js" %}"></script>
+<script src="{% static "bingosync/room/additional_settings_panel.js" %}"></script>
 <script src="{% static "bingosync/room/chat_panel.js" %}"></script>
 <script src="{% static "bingosync/room/chat_socket.js" %}"></script>
 <script src="{% static "bingosync/bingosync.js" %}"></script>
@@ -85,20 +92,33 @@
         var boardCover = new BoardCover($(".board-container"), ROOM_SETTINGS.hide_card, boardRevealedUrl);
         var playersPanel = new PlayersPanel($("#players-panel"));
         var roomSettingsPanel = new RoomSettingsPanel($("#room-settings-container"), roomSettingsUrl);
+
+
+        var additionalSettingsPanel = undefined;
+
+        // Celeste Long New is the current name of the category extensions
+        if (ROOM_SETTINGS.game == "Celeste" || ROOM_SETTINGS.game == "Celeste Long New" || ROOM_SETTINGS.game == "Custom"){
+            var additionalSettingsPanel = new AdditionalSettingsPanel($("#additional-settings-container"), $("#bingo"));
+        }
+
         var chatPanel = new ChatPanel($("#bingo-chat"), $("#chat-settings"), chatUrl, chatHistoryUrl);
         initializeChatSettings($("#chat-settings"), $("#bingo-chat"));
 
         var chatSocket = new ChatSocket(chatPanel, board, playersPanel, socketsUrl);
 
-        // hacky callback to trigger an update of the playersPanel counters whenever we update the board.
-        var updateGoalCounters = function() {
+        // hacky callback to trigger an update of the playersPanel counters (& highlighter) whenever we update the board.
+        var boardRefreshCallback = function() {
             playersPanel.updateGoalCounters(board);
-        };
+
+            if (additionalSettingsPanel !== undefined){
+                additionalSettingsPanel.newBoard();
+            }
+        }
 
         // initialize magic global hack hooks
         refreshBoard = function () {
             roomSettingsPanel.reloadSettings();
-            board.reloadBoard(updateGoalCounters);
+            board.reloadBoard(boardRefreshCallback);
         };
         hideBoard = function() {
             boardCover.setBoardHidden(true);
@@ -113,7 +133,7 @@
         window.addEventListener('resize', function() { board.refitGoalText(); }, false);
 
         // Load in all of the actual data
-        board.reloadBoard(updateGoalCounters);
+        board.reloadBoard(boardRefreshCallback);
         chatPanel.reloadChatHistory(/*full=*/false);
         chatSocket.init(temporarySocketKey);
     });


### PR DESCRIPTION
Adds a sidepanel for additional setting and populates it with a button to enable highlighting 

This panel will only appear on the games "Celeste" "Celeste Extensions" and "Custom" since the highlighter does not make sense on other generators.

Known bugs:
The dom is not regenerated on making a new card, so when switching between celeste and a game that doesn't show this the element will not disappear, I consider this minor enough to not be a serious issue.

Potential future changes:
Make it read words to highlight from a json, to support adding it to arbitrary generators. 