### PR TITLE
board cover depth with blackout view hotfix

### DIFF
--- a/bingosync-app/static/bingosync/room/additional_settings_panel.js
+++ b/bingosync-app/static/bingosync/room/additional_settings_panel.js
@@ -368,7 +368,7 @@ var AdditionalSettingsPanel = (function(){
 			BAV.square_observers[i] = new MutationObserver(squareObserverCallback);
 			BAV.square_observers[i].observe($square, { attributes: true });
 
-			$square.querySelector("div.text-container").style.zIndex = 2;
+			$square.querySelector("div.text-container").style.zIndex = 1;
 		}
 
 		const $color_buttons = document.querySelectorAll("div.color-chooser");


### PR DESCRIPTION
fix huge mess orders sticking out above the board cover when blackout view is enabled