### PR TITLE
refix board cover depth

### DIFF
--- a/bingosync-app/static/bingosync/room/additional_settings_panel.js
+++ b/bingosync-app/static/bingosync/room/additional_settings_panel.js
@@ -368,7 +368,7 @@ var AdditionalSettingsPanel = (function(){
 			BAV.square_observers[i] = new MutationObserver(squareObserverCallback);
 			BAV.square_observers[i].observe($square, { attributes: true });
 
-			$square.querySelector("div.text-container").style.zIndex = 1;
+			$square.querySelector("div.text-container").style.zIndex = 2;
 		}
 
 		const $color_buttons = document.querySelectorAll("div.color-chooser");

--- a/bingosync-app/templates/bingosync/bingosync.html
+++ b/bingosync-app/templates/bingosync/bingosync.html
@@ -23,7 +23,7 @@
                     {% include 'bingosync/color_chooser.html' %}
                 <div class="board-container{{ room.hide_card|yesno:" hidden-card," }}">
                     {% include 'bingosync/board.html' %}
-                    <div class="board-cover">
+                    <div class="board-cover" style="z-index: 3;">
                         <div class="board-cover-text unselectable">
                             Click to Reveal
                         </div>


### PR DESCRIPTION
reverts #9 and properly fixes newline breaks from appearing above the board cover

also addresses ticking objectives when the board is not revealed (also caused by the same board cover depth bug)