### PR TITLE
add scores2 api endpoint

### DIFF
--- a/bingosync-app/bingosync/urls.py
+++ b/bingosync-app/bingosync/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     url(r'^$', views.rooms, name='rooms'),
     url(r'^room/(?P<encoded_room_uuid>.+)/board$', views.room_board, name='room_board'),
     url(r'^room/(?P<encoded_room_uuid>.+)/scores$', views.room_scores, name='room_scores'),
+    url(r'^room/(?P<encoded_room_uuid>.+)/scores2$', views.room_scores2, name='room_scores2'),
     url(r'^room/(?P<encoded_room_uuid>.+)/feed$', views.room_feed, name='room_feed'),
     url(r'^room/(?P<encoded_room_uuid>.+)/disconnect$', views.room_disconnect, name='room_disconnect'),
     url(r'^room/(?P<encoded_room_uuid>.+)/room-settings$', views.room_settings, name='room_settings'),

--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -151,11 +151,57 @@ def room_scores(request, encoded_room_uuid):
         colorsDict[color] += 1
     return JsonResponse(colorsDict, safe=False)
 
+def room_scores2(request, encoded_room_uuid):
+    # TODO: Unify this with 
+    colorNames = [
+            "orange",
+            "red",
+            "blue",
+            "green",
+            "purple",
+            "navy",
+            "teal",
+            "forest",
+            "pink",
+            "yellow",
+    ]
+    lines=[
+        [1,2,3,4,5], #r1
+        [6,7,8,9,10], #r2
+        [11,12,13,14,15], #r3
+        [16,17,18,19,20], #r4
+        [21,22,23,24,25], #r5
+        [1,6,11,16,21], #c1
+        [2,7,12,17,22], #c2
+        [3,8,13,18,23], #c3
+        [4,9,14,19,24], #c4
+        [5,10,15,20,25], #c5
+        [1,7,13,19,25], #rtlbr
+        [5,9,13,17,21], #rtlbr
+    ]
+
+    room = Room.get_for_encoded_uuid_or_404(encoded_room_uuid)
+    squareColors = [(sublist.slot, item.name) for sublist in room.current_game.squares for item in sublist.color.colors]
+    colorSquares = {}
+    for color in colorNames:
+        colorSquares[color] = []
+    for (slot, color) in squareColors:
+        colorSquares[color].append(slot)
+
+    res = {}
+    for color in colorNames:
+        squares=colorSquares[color]
+        count = len(squares)
+        lines = sum((all(slot in squares for slot in line)) for line in lines)
+    
+    return JsonResponse(res, safe=False)
+
+
 # AJAX view to render the room settings panel
 def room_settings(request, encoded_room_uuid):
     room = Room.get_for_encoded_uuid(encoded_room_uuid)
     panel = loader.get_template("bingosync/room_settings_panel.html").render({"game": room.current_game, "room": room}, request)
-    return JsonResponse({"panel": panel, "settings": room.settings});
+    return JsonResponse({"panel": panel, "settings": room.settings})
 
 @csrf_exempt
 def new_card(request):

--- a/bingosync-app/bingosync/views.py
+++ b/bingosync-app/bingosync/views.py
@@ -181,18 +181,20 @@ def room_scores2(request, encoded_room_uuid):
     ]
 
     room = Room.get_for_encoded_uuid_or_404(encoded_room_uuid)
-    squareColors = [(sublist.slot, item.name) for sublist in room.current_game.squares for item in sublist.color.colors]
+    squareColors = [(sublist.slot, item.name) for sublist in room.current_game.squares for item in sublist.color.colors if item.name != "blank"]
     colorSquares = {}
     for color in colorNames:
         colorSquares[color] = []
     for (slot, color) in squareColors:
+        print(slot, color)
         colorSquares[color].append(slot)
 
     res = {}
     for color in colorNames:
         squares=colorSquares[color]
         count = len(squares)
-        lines = sum((all(slot in squares for slot in line)) for line in lines)
+        linesCount = sum((all(slot in squares for slot in line)) for line in lines)
+        res[color] = {"score": count, "lines": linesCount}
     
     return JsonResponse(res, safe=False)
 


### PR DESCRIPTION
Adds new `/scores2` endpoint similar to the existing `/scores` endpoint, but with a more robust syntax.

<img width="600" height="547" alt="image" src="https://github.com/user-attachments/assets/6b144c0c-45f1-46da-be31-6794657b99e5" />

```{
  "orange": {
    "score": 0,
    "lines": 0
  },
  "red": {
    "score": 5,
    "lines": 1
  },
  "blue": {
    "score": 0,
    "lines": 0
  },
  "green": {
    "score": 13,
    "lines": 3
  },
  "purple": {
    "score": 2,
    "lines": 0
  },
  "navy": {
    "score": 0,
    "lines": 0
  },
  "teal": {
    "score": 0,
    "lines": 0
  },
  "forest": {
    "score": 0,
    "lines": 0
  },
  "pink": {
    "score": 0,
    "lines": 0
  },
  "yellow": {
    "score": 0,
    "lines": 0
  }
}
```